### PR TITLE
Added prop-types as a separate dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "standard": "^5.3.1"
   },
   "dependencies": {
+    "prop-types": "15.6.1",
     "lodash.map": "^3.1.4"
   }
 }

--- a/src/textselect.jsx
+++ b/src/textselect.jsx
@@ -1,12 +1,13 @@
 var React = require('react')
+var PropTypes = require('prop-types')
 var lodashMap = require('lodash.map')
 
 var TextSelect = React.createClass({
   propTypes: {
-    options: React.PropTypes.any.isRequired,
-    active: React.PropTypes.any.isRequired,
-    onChange: React.PropTypes.func.isRequired,
-    className: React.PropTypes.string
+    options: PropTypes.any.isRequired,
+    active: PropTypes.any.isRequired,
+    onChange: PropTypes.func.isRequired,
+    className: PropTypes.string
   },
 
   handleChange (event) {


### PR DESCRIPTION
React.PropTypes is deprecated in 15.5+ and removed in 16. This change adds the dependency on prop-types which is split out from React.